### PR TITLE
Add minimum image age option

### DIFF
--- a/gc/collector.go
+++ b/gc/collector.go
@@ -27,10 +27,11 @@ type Collector interface {
 type collector struct {
 	client docker.APIClient
 
-	whitelist []string // reserved containers
-	reserved  []string // reserved images
-	threshold int64    // target threshold in bytes
-	filter    FilterFunc
+	whitelist   []string // reserved containers
+	reserved    []string // reserved images
+	threshold   int64    // target threshold in bytes
+	minImageAge time.Duration
+	filter      FilterFunc
 }
 
 // New returns a garbage collector.

--- a/gc/image.go
+++ b/gc/image.go
@@ -72,7 +72,7 @@ func (c *collector) collectImages(ctx context.Context) error {
 		if isImageUsed(image, df.Containers) {
 			continue
 		}
-		if time.Unix(image.Created, 0).Add(time.Hour).After(now) {
+		if time.Unix(image.Created, 0).Add(c.minImageAge).After(now) {
 			continue
 		}
 

--- a/gc/option.go
+++ b/gc/option.go
@@ -4,6 +4,8 @@
 
 package gc
 
+import "time"
+
 // Option configures a garbage collector option.
 type Option func(*collector)
 
@@ -31,6 +33,15 @@ func WithWhitelist(names []string) Option {
 func WithThreshold(threshold int64) Option {
 	return func(c *collector) {
 		c.threshold = threshold
+	}
+}
+
+// WithMinImageAge returns an option to set the minimum
+// age a image should be to become a candidate for removal.
+// Images younger than this value won't be removed
+func WithMinImageAge(minImageAge time.Duration) Option {
+	return func(c *collector) {
+		c.minImageAge = minImageAge
 	}
 }
 

--- a/gc/option_test.go
+++ b/gc/option_test.go
@@ -7,13 +7,16 @@ package gc
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestOptions(t *testing.T) {
+	expectedMinImageAge, _ := time.ParseDuration("5h")
 	c := New(nil,
 		WithImageWhitelist([]string{"foo"}),
 		WithThreshold(42),
 		WithWhitelist([]string{"bar"}),
+		WithMinImageAge(expectedMinImageAge),
 	).(*collector)
 
 	if got, want := c.threshold, int64(42); got != want {
@@ -24,5 +27,9 @@ func TestOptions(t *testing.T) {
 	}
 	if got, want := c.reserved, []string{"foo"}; !reflect.DeepEqual(want, got) {
 		t.Errorf("Want image whitelist %v, got %v", want, got)
+	}
+
+	if got, want := c.minImageAge, expectedMinImageAge; !reflect.DeepEqual(want, got) {
+		t.Errorf("Want minImageAge %v, got %v", want, got)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -21,14 +21,15 @@ import (
 )
 
 type config struct {
-	Once       bool          `envconfig:"GC_ONCE"`
-	Debug      bool          `envconfig:"GC_DEBUG"`
-	Color      bool          `envconfig:"GC_DEBUG_COLOR"`
-	Pretty     bool          `envconfig:"GC_DEBUG_PRETTY"`
-	Images     []string      `envconfig:"GC_IGNORE_IMAGES"`
-	Containers []string      `envconfig:"GC_IGNORE_CONTAINERS"`
-	Interval   time.Duration `envconfig:"GC_INTERVAL" default:"5m"`
-	Cache      string        `envconfig:"GC_CACHE" default:"5gb"`
+	Once        bool          `envconfig:"GC_ONCE"`
+	Debug       bool          `envconfig:"GC_DEBUG"`
+	Color       bool          `envconfig:"GC_DEBUG_COLOR"`
+	Pretty      bool          `envconfig:"GC_DEBUG_PRETTY"`
+	Images      []string      `envconfig:"GC_IGNORE_IMAGES"`
+	Containers  []string      `envconfig:"GC_IGNORE_CONTAINERS"`
+	Interval    time.Duration `envconfig:"GC_INTERVAL" default:"5m"`
+	MinImageAge time.Duration `envconfig:"GC_MIN_IMAGE_AGE" default:"1h"`
+	Cache       string        `envconfig:"GC_CACHE" default:"5gb"`
 }
 
 func main() {
@@ -61,6 +62,7 @@ func main() {
 		gc.WithImageWhitelist(cfg.Images),
 		gc.WithThreshold(size),
 		gc.WithWhitelist(gc.ReservedNames),
+		gc.WithMinImageAge(cfg.MinImageAge),
 		gc.WithWhitelist(cfg.Containers),
 	)
 	if cfg.Once {
@@ -71,6 +73,7 @@ func main() {
 			Strs("ignore-images", cfg.Images).
 			Str("cache", cfg.Cache).
 			Str("interval", units.HumanDuration(cfg.Interval)).
+			Str("minimal image age", units.HumanDuration(cfg.MinImageAge)).
 			Msg("starting the garbage collector")
 
 		gc.Schedule(ctx, collector, cfg.Interval)


### PR DESCRIPTION
The current implementation of DroneGC only considers images that were created more than one hour ago.  This PR makes that image age time configurable via the `MinImageAge` option. If such option is not available, the minimum image age is remains 1 hour.